### PR TITLE
(maint) Unpinning specific changelog generator version

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,7 +3,4 @@ Gemfile:
   optional:
     ':development':
       - gem: 'github_changelog_generator'
-        git: 'https://github.com/skywinder/github-changelog-generator'
-        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
 


### PR DESCRIPTION
Previously to make use of functionality we needed to pin version, however this has been released and we no longer need to pin the version of github changelog generator gem that we use.