### PR TITLE
Allow module to work with bundled gem

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,5 +9,7 @@ fixtures:
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     provision: 'https://github.com/puppetlabs/provision.git'
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+  forge_modules:
+    hocon: "puppetlabs/hocon"
   symlinks:
     dropsonde: "#{source_dir}"

--- a/lib/facter/dropsonde.rb
+++ b/lib/facter/dropsonde.rb
@@ -5,10 +5,10 @@ Facter.add(:dropsonde) do
 
   setcode do
     cmd = '/opt/puppetlabs/bin/puppetserver dropsonde --version'
-    rgx = /dropsonde version (\d\.\d\.\d)/
+    rgx = %r{dropsonde version (\d\.\d\.\d)}
     {
-      :bundled => true,
-      :version => Facter::Core::Execution.execute(cmd, :on_fail => nil)&.match(rgx)&.captures&.first,
+      bundled: true,
+      version: Facter::Core::Execution.execute(cmd, on_fail: nil)&.match(rgx)&.captures&.first,
     }
   end
 end

--- a/lib/facter/dropsonde.rb
+++ b/lib/facter/dropsonde.rb
@@ -1,0 +1,14 @@
+Facter.add(:dropsonde) do
+  confine do
+    File.exist?('/opt/puppetlabs/server/apps/puppetserver/cli/apps/dropsonde')
+  end
+
+  setcode do
+    cmd = '/opt/puppetlabs/bin/puppetserver dropsonde --version'
+    rgx = /dropsonde version (\d\.\d\.\d)/
+    {
+      :bundled => true,
+      :version => Facter::Core::Execution.execute(cmd, :on_fail => nil)&.match(rgx)&.captures&.first,
+    }
+  end
+end

--- a/lib/puppet/functions/dropsonde/to_symbolized_yaml.rb
+++ b/lib/puppet/functions/dropsonde/to_symbolized_yaml.rb
@@ -28,7 +28,7 @@ Puppet::Functions.create_function(:'dropsonde::to_symbolized_yaml') do
   end
 
   def to_yaml(data, options = {})
-    config = data.map { |k,v| [k.to_sym, v] }.to_h
+    config = data.map { |k, v| [k.to_sym, v] }.to_h
     config.to_yaml(options)
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,10 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-dropsonde",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-dropsonde/issues",
   "dependencies": [
-
+    {
+       "name": "puppetlabs/hocon",
+       "version_requirement": ">= 1.1.0 < 2.0.0"
+     }
   ],
   "operatingsystem_support": [
     {

--- a/spec/acceptance/10_base_spec.rb
+++ b/spec/acceptance/10_base_spec.rb
@@ -3,26 +3,7 @@
 require 'spec_helper_acceptance'
 
 describe 'dropsonde base configuration' do
-  context 'with use_cron => false' do
-    let(:dropsonde_manifest) do
-      <<-MANIFEST
-        class { 'dropsonde':
-          use_cron => false,
-        }
-      MANIFEST
-    end
-
-    after(:all) do
-      # remove the dropsonde gem
-      run_shell('yes | /opt/puppetlabs/puppet/bin/gem uninstall dropsonde')
-    end
-
-    it 'runs successfully' do
-      idempotent_apply(dropsonde_manifest)
-    end
-  end
-
-  context 'with enabled => true and use_cron => true' do
+  context 'with enabled => true' do
     let(:dropsonde_manifest) { 'include dropsonde' }
 
     before(:all) do
@@ -58,7 +39,7 @@ describe 'dropsonde base configuration' do
     end
   end
 
-  context 'with enabled => false and use_cron => true' do
+  context 'with enabled => false' do
     let(:dropsonde_manifest) do
       <<-MANIFEST
         class { 'dropsonde':

--- a/spec/classes/dropsonde_spec.rb
+++ b/spec/classes/dropsonde_spec.rb
@@ -8,18 +8,44 @@ describe 'dropsonde' do
       it { is_expected.to compile }
     end
 
-    context "on #{os} with enabled => false" do
+    context "on #{os} with legacy installation and enabled => false" do
       let(:facts) { os_facts }
       let(:params) { { enabled: false } }
 
+      it { is_expected.to contain_package('dropsonde').with_ensure('latest') }
       it { is_expected.to contain_cron('submit Puppet telemetry report').with_ensure('absent') }
     end
 
-    context "on #{os} with use_cron => false" do
+    context "on #{os} with legacy installation and enabled => true" do
       let(:facts) { os_facts }
-      let(:params) { { use_cron: false } }
+      let(:params) { { enabled: true } }
 
-      it { is_expected.not_to contain_cron('submit Puppet telemetry report') }
+      it { is_expected.to contain_package('dropsonde').with_ensure('latest') }
+      it { is_expected.to contain_cron('submit Puppet telemetry report').with_ensure('present') }
     end
+
+
+    context "on #{os} with vendored client and enabled => false" do
+      let(:facts) {
+        os_facts.merge({
+          :dropsonde => {:bundled => true, :version => '0.0.6'},
+        })
+      }
+      let(:params) { { enabled: false } }
+
+      it { is_expected.to contain_hocon_setting('submit Puppet telemetry report').with_value(false) }
+    end
+
+    context "on #{os} with vendored client and enabled => true" do
+      let(:facts) {
+        os_facts.merge({
+          :dropsonde => {:bundled => true, :version => '0.0.6'},
+        })
+      }
+      let(:params) { { enabled: true } }
+
+      it { is_expected.to contain_hocon_setting('submit Puppet telemetry report').with_value(true) }
+    end
+
   end
 end

--- a/spec/classes/dropsonde_spec.rb
+++ b/spec/classes/dropsonde_spec.rb
@@ -24,28 +24,26 @@ describe 'dropsonde' do
       it { is_expected.to contain_cron('submit Puppet telemetry report').with_ensure('present') }
     end
 
-
     context "on #{os} with vendored client and enabled => false" do
-      let(:facts) {
+      let(:facts) do
         os_facts.merge({
-          :dropsonde => {:bundled => true, :version => '0.0.6'},
-        })
-      }
+                         dropsonde: { bundled: true, version: '0.0.6' },
+                       })
+      end
       let(:params) { { enabled: false } }
 
       it { is_expected.to contain_hocon_setting('submit Puppet telemetry report').with_value(false) }
     end
 
     context "on #{os} with vendored client and enabled => true" do
-      let(:facts) {
+      let(:facts) do
         os_facts.merge({
-          :dropsonde => {:bundled => true, :version => '0.0.6'},
-        })
-      }
+                         dropsonde: { bundled: true, version: '0.0.6' },
+                       })
+      end
       let(:params) { { enabled: true } }
 
       it { is_expected.to contain_hocon_setting('submit Puppet telemetry report').with_value(true) }
     end
-
   end
 end


### PR DESCRIPTION
A few things have changed now that the gem is bundled. We don't need to
manage installation anymore, and it's scheduled with the built-in
tkscheduler. Instead of managing a cron job, we'll just turn it on.

Note that I didn't bother to update the Litmus tests because they'll all
fail until the images are updated with the latest release, and I don't
know how to choose the Puppetserver version to install anyway! 🤷